### PR TITLE
Добавлен тест Project Submitted Notification и корректировка импорт тестов

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,3 +36,8 @@ jwt:
 telegram:
   init-data: user=%7B%22id%22%3A531455701%2C%22first_name%22%3A%22%D0%9C%D0%B0%D1%80%D0%BA%22%2C%22last_name%22%3A%22%22%2C%22username%22%3A%22yeahigh%22%2C%22language_code%22%3A%22ru%22%2C%22photo_url%22%3A%22https%3A%5C%2F%5C%2Ft.me%5C%2Fi%5C%2Fuserpic%5C%2F320%5C%2FjeCwwKkabH7uU8K6ALqVFhodLV3KS-AXrt6vvm4okKc.svg%22%7D&chat_instance=-7061379911278325128&chat_type=supergroup&auth_date=1777060225&signature=uxESH6NQkg1q-otcmLaqjGJUF3tyKsYK3Sh98C2XpBBC2aZN3f-tJPfp8rV1OU0rj2VJYTgKBmjCX7IOcrpUBg&hash=2f1c5fb7b9cf74f1fcafbda3c800efb76ffb1117ea1358b4692e304806f5be6c
   updated-init-data: user=%7B%22id%22%3A531455701%2C%22first_name%22%3A%22%D0%9C%D0%B0%D1%80%D0%BA%22%2C%22last_name%22%3A%22%D0%A0%22%2C%22username%22%3A%22yeahigh%22%2C%22language_code%22%3A%22ru%22%2C%22photo_url%22%3A%22https%3A%5C%2F%5C%2Ft.me%5C%2Fi%5C%2Fuserpic%5C%2F320%5C%2FjeCwwKkabH7uU8K6ALqVFhodLV3KS-AXrt6vvm4okKc.svg%22%7D&chat_instance=3294457520524516638&chat_type=sender&auth_date=1777148749&signature=BLr0rSsq6Y-a-i5u2NxaWqIYohC_Mq6b4-15uYVS_w0Dztx_X7U4b2kdTcEuR5iRPb5YA3gYsDDpFkEVesboBw&hash=1bb1025a2e4cff2acfe37cf2e9648c81095659c9e760edeb7004cfa5a3bc9227
+
+telegram-bot-adapter:
+  auth:
+    username: ${TELEGRAM_ADAPTER_USERNAME:username}
+    password: ${TELEGRAM_ADAPTER_PASSWORD:password}

--- a/src/test/java/org/example/e2etests/config/TestcontainersConfig.java
+++ b/src/test/java/org/example/e2etests/config/TestcontainersConfig.java
@@ -21,6 +21,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.PullPolicy;
 import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -41,7 +42,8 @@ public class TestcontainersConfig {
     private static final List<String> REQUIRED_TOPICS = List.of(
             "auth.user.created",
             "auth.user.authenticated",
-            "projects.project.created"
+            "projects.project.created",
+            "notifications.mentors.project.submitted"
     );
 
     @Value("${jwt.secret}")
@@ -221,6 +223,7 @@ public class TestcontainersConfig {
         String serviceName = imagePath.substring(imagePath.lastIndexOf('/') + 1);
         return new GenericContainer<>(GHCR + "/" + imagePath + ":" + tag)
                 .withNetwork(network)
+                .withImagePullPolicy(PullPolicy.alwaysPull())
                 .withEnv("SPRING_PROFILES_ACTIVE", "local-stack")
                 .withEnv("SPRING_KAFKA_BOOTSTRAP_SERVERS", "kafka:19092")
                 .withExposedPorts(8080)

--- a/src/test/java/org/example/e2etests/tests/base/E2eTestBase.java
+++ b/src/test/java/org/example/e2etests/tests/base/E2eTestBase.java
@@ -13,6 +13,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.kafka.KafkaContainer;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.crypto.SecretKey;
 import java.util.Base64;
@@ -20,6 +21,20 @@ import java.util.Base64;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(TestcontainersConfig.class)
 public abstract class E2eTestBase {
+    protected static final String AUTH_SERVICE_USERS_TABLE = "auth_service.users";
+    protected static final String AUTH_SERVICE_USERS_ROLES_TABLE = "auth_service.users";
+    protected static final String PROJECT_SERVICE_PROJECTS_TABLE = "project_service.projects";
+    protected static final String PROFILE_SERVICE_PROFILES_TABLE = "profile_service.profiles";
+    protected static final String PROFILE_SERVICE_PROJECT_TABLE = "profile_service.project";
+    protected static final String MENTOR_SERVICE_MENTORS_TABLE = "mentor_service.mentors";
+    protected static final String MENTOR_SERVICE_GUARANTEED_REVIEWS_PRICES_TABLE = "mentor_service.guaranteed_reviews_prices";
+    protected static final String BOT_ADAPTER_TELEGRAM_BOT_TASKS_TABLE = "telegram_bot_adapter.telegram_bot_tasks";
+    protected static final String PROJECTS_PROJECT_CREATED_TOPIC = "projects.project.created";
+    protected static final String NOTIFICATIONS_MENTORS_PROJECT_SUBMITTED_TOPIC = "notifications.mentors.project.submitted";
+    protected static final String AUTH_ENDPOINT = "/api/auth/by-telegram";
+    protected static final String PROJECT_FRONTEND_ENDPOINT = "/api/project/project";
+    protected static final String BOT_TASKS_ENDPOINT_COUNT_10 = "/api/telegram-bot-adapter/tasks?count=10";
+
     @Value("${jwt.secret}")
     protected String jwtSecret;
     @Value("${telegram.init-data}")
@@ -28,6 +43,10 @@ public abstract class E2eTestBase {
     protected String updatedTelegramInitData;
     @Value("${GOOGLE_TEST_SPREADSHEET_ID}")
     protected String testSpreadsheetId;
+    @Value("${telegram-bot-adapter.auth.username}")
+    protected String botUsername;
+    @Value("${telegram-bot-adapter.auth.password}")
+    protected String botPassword;
     @Autowired
     protected GoogleSheetsClient googleSheetsHelper;
     @Autowired
@@ -56,6 +75,8 @@ public abstract class E2eTestBase {
     protected GenericContainer<?> telegramBotAdapter;
     @Autowired
     protected TestRestTemplate testRestTemplate;
+    @Autowired
+    protected ObjectMapper objectMapper;
 
     protected SecretKey secretKey() {
         return Keys.hmacShaKeyFor(Base64.getDecoder().decode(jwtSecret));

--- a/src/test/java/org/example/e2etests/tests/data/DataImporterE2eTest.java
+++ b/src/test/java/org/example/e2etests/tests/data/DataImporterE2eTest.java
@@ -5,7 +5,7 @@ import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.example.e2etests.tests.base.E2eTestBase;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.test.jdbc.JdbcTestUtils;
@@ -22,7 +22,7 @@ import static org.example.e2etests.HttpHeadersTestUtils.createHeaders;
 @Slf4j
 public class DataImporterE2eTest extends E2eTestBase {
 
-    @AfterEach
+    @BeforeEach
     void setUp() {
         jdbcTemplate.execute("TRUNCATE TABLE auth_service.users RESTART IDENTITY CASCADE");
         jdbcTemplate.execute("TRUNCATE TABLE profile_service.profiles RESTART IDENTITY CASCADE");

--- a/src/test/java/org/example/e2etests/tests/data/ProjectSubmittedNotificationE2eTest.java
+++ b/src/test/java/org/example/e2etests/tests/data/ProjectSubmittedNotificationE2eTest.java
@@ -1,0 +1,248 @@
+package org.example.e2etests.tests.data;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.assertj.core.api.Assertions;
+import org.example.e2etests.dto.CreateProjectRequest;
+import org.example.e2etests.tests.base.E2eTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
+import org.springframework.test.jdbc.JdbcTestUtils;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.example.e2etests.HttpHeadersTestUtils.createHeaders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Slf4j
+public class ProjectSubmittedNotificationE2eTest extends E2eTestBase {
+
+    private static final String GITHUB_REPOSITORY_URL = "https://github.com/zhukovsd/currency-exchange-testNotificationMentor";
+    private static final String PROGRAMMING_LANGUAGE = "JAVA";
+    private static final String ROADMAP_PROJECT = "CURRENCY-EXCHANGE";
+    private static final String UPDATED_PROJECT = "CURRENCY_EXCHANGE";
+    private static final int REVIEW_PRICE = 10;
+    private static final String MENTOR_TELEGRAM_URL = "https://github.com/zhukovsd-mentor1";
+    private static final long MENTOR_ID = 12745679L;
+
+    private static final List<String> TABLES_TO_TRUNCATE = List.of(
+            AUTH_SERVICE_USERS_TABLE,
+            PROJECT_SERVICE_PROJECTS_TABLE,
+            PROFILE_SERVICE_PROJECT_TABLE,
+            PROFILE_SERVICE_PROFILES_TABLE,
+            BOT_ADAPTER_TELEGRAM_BOT_TASKS_TABLE,
+            MENTOR_SERVICE_MENTORS_TABLE,
+            MENTOR_SERVICE_GUARANTEED_REVIEWS_PRICES_TABLE
+    );
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.execute(
+                """
+                        TRUNCATE TABLE %s
+                        RESTART IDENTITY CASCADE
+                        """.formatted(String.join(", ", TABLES_TO_TRUNCATE))
+        );
+
+        assertTableIsEmpty(AUTH_SERVICE_USERS_TABLE);
+        assertTableIsEmpty(PROJECT_SERVICE_PROJECTS_TABLE);
+        assertTableIsEmpty(PROFILE_SERVICE_PROJECT_TABLE);
+        assertTableIsEmpty(PROFILE_SERVICE_PROFILES_TABLE);
+        assertTableIsEmpty(BOT_ADAPTER_TELEGRAM_BOT_TASKS_TABLE);
+        assertTableIsEmpty(MENTOR_SERVICE_MENTORS_TABLE);
+        assertTableIsEmpty(MENTOR_SERVICE_GUARANTEED_REVIEWS_PRICES_TABLE);
+        assertKafkaTopicEmpty(List.of(
+                PROJECTS_PROJECT_CREATED_TOPIC,
+                NOTIFICATIONS_MENTORS_PROJECT_SUBMITTED_TOPIC));
+    }
+
+    @Test
+    void shouldCreateNotificationTaskWhenSubmittingProject() throws IOException {
+        createMentor();
+        String accessToken = authenticateViaTelegram(telegramInitData);
+        createProjectViaFrontend(accessToken);
+        getBotTasks();
+    }
+
+    private String authenticateViaTelegram(String telegramInitData) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_PLAIN);
+        HttpEntity<String> request = new HttpEntity<>(telegramInitData, headers);
+
+        ResponseEntity<String> response = testRestTemplate.postForEntity(
+                AUTH_ENDPOINT,
+                request,
+                String.class
+        );
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        String accessToken = response.getHeaders().getFirst("X-Access-Token");
+        Assertions.assertThat(accessToken).isNotNull();
+
+        Claims claims = parseJwt(accessToken);
+        long telegramUserId = extractTelegramUserIdFrom(claims);
+
+        String clause = "telegram_user_id='%s'".formatted(telegramUserId);
+        assertTableHasOneRecord(AUTH_SERVICE_USERS_TABLE, clause);
+        await().atMost(30, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() ->
+                        assertTableHasOneRecord(PROFILE_SERVICE_PROFILES_TABLE, clause)
+                );
+        return accessToken;
+    }
+
+    private void createProjectViaFrontend(String accessToken) {
+        CreateProjectRequest requestBody = CreateProjectRequest.builder()
+                .githubRepositoryUrl(GITHUB_REPOSITORY_URL)
+                .programmingLanguage(PROGRAMMING_LANGUAGE)
+                .roadmapProject(ROADMAP_PROJECT)
+                .build();
+
+        HttpEntity<CreateProjectRequest> requestEntity = new HttpEntity<>(requestBody, createHeaders(accessToken));
+        ResponseEntity<String> response = testRestTemplate.postForEntity(
+                PROJECT_FRONTEND_ENDPOINT,
+                requestEntity,
+                String.class
+        );
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+        Claims claims = parseJwt(accessToken);
+        long telegramUserId = extractTelegramUserIdFrom(claims);
+
+        String clause = "author_telegram_user_id='%s'".formatted(telegramUserId);
+        assertTableHasOneRecord(PROJECT_SERVICE_PROJECTS_TABLE, clause);
+        await().atMost(30, TimeUnit.SECONDS)
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    assertProjectPersistedInGoogleSheet();
+                    assertTableHasOneRecord(PROFILE_SERVICE_PROJECT_TABLE, clause);
+                    assertNotificationTaskPersistedInDatabase(NOTIFICATIONS_MENTORS_PROJECT_SUBMITTED_TOPIC);
+                });
+    }
+
+    private void getBotTasks() throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth(botUsername, botPassword);
+
+        ResponseEntity<String> response = testRestTemplate.exchange(
+                BOT_TASKS_ENDPOINT_COUNT_10,
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                String.class
+        );
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        JsonNode tasks = objectMapper.readTree(response.getBody()).get("tasks");
+        JsonNode notificationTask = StreamSupport.stream(tasks.spliterator(), false)
+                .filter(task ->
+                        NOTIFICATIONS_MENTORS_PROJECT_SUBMITTED_TOPIC.equals(
+                                task.path("taskType").asText()
+                        )
+                )
+                .findFirst()
+                .orElseThrow();
+
+        JsonNode mentors = notificationTask.path("payload").path("mentors");
+        assertThat(mentors.get(0)
+                .path("mentor_telegram_user_id")
+                .asLong()
+        ).isEqualTo(MENTOR_ID);
+    }
+
+    private void assertTableHasOneRecord(String tableName, String clause) {
+        int count = JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, tableName, clause);
+        assertThat(count).isOne();
+    }
+
+    private void assertTableIsEmpty(String tableName) {
+        int count = JdbcTestUtils.countRowsInTable(jdbcTemplate, tableName);
+        assertThat(count).isZero();
+    }
+
+    private void assertNotificationTaskPersistedInDatabase(String taskType) throws JsonProcessingException {
+        String payload = jdbcTemplate.queryForObject(
+                """
+                        SELECT payload::text
+                        FROM telegram_bot_adapter.telegram_bot_tasks
+                        WHERE task_type = ?
+                        """,
+                String.class,
+                taskType
+        );
+        Assertions.assertThat(payload).isNotBlank();
+
+        JsonNode mentors = objectMapper.readTree(payload).path("mentors");
+        assertThat(
+                mentors.get(0)
+                        .path("mentor_telegram_user_id")
+                        .asLong()
+        ).isEqualTo(MENTOR_ID);
+    }
+
+    private void assertProjectPersistedInGoogleSheet() throws IOException {
+        boolean projectFound = googleSheetsHelper.readSheet(testSpreadsheetId, "Projects!A:ZZ").stream()
+                .anyMatch(row -> row.toString().contains(GITHUB_REPOSITORY_URL));
+        assertThat(projectFound).isTrue();
+    }
+
+    private void assertKafkaTopicEmpty(List<String> topics) {
+        kafkaConsumer.subscribe(topics);
+        kafkaConsumer.poll(Duration.ofMillis(500));
+        kafkaConsumer.seekToEnd(kafkaConsumer.assignment());
+
+        ConsumerRecords<String, String> records = kafkaConsumer.poll(Duration.ofSeconds(2));
+        assertThat(records.count()).isZero();
+    }
+
+    private Claims parseJwt(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private Long extractTelegramUserIdFrom(Claims claims) {
+        Assertions.assertThat(claims.getSubject()).isNotBlank();
+        return Long.parseLong(claims.getSubject());
+    }
+
+    private void createMentor() {
+        Long mentorId = jdbcTemplate.queryForObject(
+                """
+                        INSERT INTO mentor_service.mentors (mentor_telegram_user_id, telegram_url, is_active)
+                        VALUES (?, ?, ?)
+                        RETURNING id
+                        """,
+                Long.class,
+                MENTOR_ID,
+                MENTOR_TELEGRAM_URL,
+                true
+        );
+
+        jdbcTemplate.update(
+                """
+                        INSERT INTO mentor_service.guaranteed_reviews_prices
+                            (mentor_id, project_type, language, price_usd)
+                        VALUES (?, ?, ?, ?)
+                        """,
+                mentorId,
+                UPDATED_PROJECT,
+                PROGRAMMING_LANGUAGE,
+                REVIEW_PRICE
+        );
+    }
+
+}

--- a/src/test/java/org/example/e2etests/tests/data/ProjectsImportTest.java
+++ b/src/test/java/org/example/e2etests/tests/data/ProjectsImportTest.java
@@ -149,9 +149,10 @@ public class ProjectsImportTest extends E2eTestBase {
 
         startImport("/api/project/internal/project", requestBody);
 
+        String clause = "task_type='%s'".formatted(PROJECTS_PROJECT_CREATED_TOPIC);
         await().atMost(20, TimeUnit.SECONDS)
                 .untilAsserted(() ->
-                        assertTableIsEmpty("telegram_bot_adapter.telegram_bot_tasks")
+                        assertTableIsEmpty("telegram_bot_adapter.telegram_bot_tasks", clause)
                 );
     }
 
@@ -168,6 +169,11 @@ public class ProjectsImportTest extends E2eTestBase {
 
     private void assertTableIsEmpty(String tableName) {
         int count = JdbcTestUtils.countRowsInTable(jdbcTemplate, tableName);
+        assertThat(count).isZero();
+    }
+
+    private void assertTableIsEmpty(String tableName, String clause) {
+        int count = JdbcTestUtils.countRowsInTableWhere(jdbcTemplate, tableName, clause);
         assertThat(count).isZero();
     }
 


### PR DESCRIPTION
- добавился новый e2e теста ProjectSubmittedNotification
- добавились секреты для Auth Telegram-bot-adapter
- добавился в конфигурацию контейнеров топик notifications.mentors.project.submitted и PullPolicy.alwaysPull
- добавились константы названия таблиц, эндпоинтов, топиков
- теперь тест shouldNotCreateTelegramBotTaskWhenProjectCreatedFromTelegramBot проверяет только на отсутствие топика projects.project.created
- в классе DataImporterE2eTest теперь очищаются таблицы до начала теста